### PR TITLE
Prepend uri.request_uri to JENX_API_URL

### DIFF
--- a/jenx/JenxConnection.rb
+++ b/jenx/JenxConnection.rb
@@ -30,7 +30,7 @@ class JenxConnection
             uri = URI.parse(@url)
             http = Net::HTTP.new(uri.host, uri.port)
             initSSL(http, uri.scheme)
-            req = Net::HTTP::Get.new(JENX_API_URI)
+            req = Net::HTTP::Get.new(uri.request_uri + JENX_API_URI)
             auth(req)
             response = http.request(req)
             if response.code_type == Net::HTTPOK then
@@ -46,7 +46,7 @@ class JenxConnection
             uri = URI.parse(@url)
             http = Net::HTTP.new(uri.host, uri.port)
             initSSL(http, uri.scheme)
-            req = Net::HTTP::Head.new(JENX_API_URI)
+            req = Net::HTTP::Head.new(uri.request_uri + JENX_API_URI)
             auth(req)
             response = http.request(req)
             response.code_type == Net::HTTPOK


### PR DESCRIPTION
Prepend uri.request_uri to JENX_API_URL so that Jenkins installations not at the root are supported.
