### PR TITLE
Fix https://github.com/urbancoding/jenx/issues/30

### DIFF
--- a/jenx/JenxConnection.rb
+++ b/jenx/JenxConnection.rb
@@ -26,8 +26,14 @@ class JenxConnection
     end
 
     def all_projects
+        uri = URI.parse(@url)
+        
+        if !uri.respond_to?(:request_uri) then
+            NSLog("Failed to load list of projects from @url = \"#{@url}\"")
+            return {'jobs' => []}
+        end
+        
         connection_result = JenxConnectionManager.new do
-            uri = URI.parse(@url)
             http = Net::HTTP.new(uri.host, uri.port)
             initSSL(http, uri.scheme)
             req = Net::HTTP::Get.new(JENX_API_URI)

--- a/jenx/PreferencesGeneralViewController.rb
+++ b/jenx/PreferencesGeneralViewController.rb
@@ -63,7 +63,7 @@ class PreferencesGeneralViewController <  NSViewController
             else
                 @project_list.selectItemWithObjectValue(@prefs.default_project)
             end
-        rescue InvalidURIError => uri_error
+        rescue URI::InvalidURIError => uri_error
             NSLog(uri_error)
         rescue Exception => error
             NSLog(error)


### PR DESCRIPTION
Fix https://github.com/urbancoding/jenx/issues/30 ("With invalid Build Server URL, Load Projects causes Ruby errors in Console.app")
- `InvalidURIError` => `URI::InvalidURIError`
- Add error checking for URIs that are not parsable.
