### PR TITLE
Fix GH-8: Comment out @refresh_timer.invalidate in Jenx::handle_broken_connection.

### DIFF
--- a/jenx/Jenx.rb
+++ b/jenx/Jenx.rb
@@ -110,7 +110,8 @@ class Jenx
     end
     
     def handle_broken_connection(error_type)
-        @refresh_timer.invalidate
+		# Comment out invalidate to fix issue GH-8
+        # @refresh_timer.invalidate
         NSLog("#{CONNECTION_ERROR_TITLE}: #{error_type}")
         @jenx_item.setImage(@build_failure_icon)
         


### PR DESCRIPTION
Fixes GH-8.
