### PR TITLE
Change two NSLog statements to log exceptions by calling `inspect`

### DIFF
--- a/jenx/PreferencesGeneralViewController.rb
+++ b/jenx/PreferencesGeneralViewController.rb
@@ -64,9 +64,9 @@ class PreferencesGeneralViewController <  NSViewController
                 @project_list.selectItemWithObjectValue(@prefs.default_project)
             end
         rescue URI::InvalidURIError => uri_error
-            NSLog(uri_error)
+            NSLog(uri_error.inspect)
         rescue Exception => error
-            NSLog(error)
+            NSLog(error.inspect)
         end
     end
     


### PR DESCRIPTION
Change two NSLog statements to log exceptions by calling `inspect` on them as NSLog can't take the exceptions directly and this causes MacRuby
to crash (See https://www.macruby.org/trac/ticket/1447).

Fixes GH-40.
