### PR TITLE
Fix GH-37: Jenx is unresponsive while retrieving status

### DIFF
--- a/jenx/PreferencesGeneralViewController.rb
+++ b/jenx/PreferencesGeneralViewController.rb
@@ -53,15 +53,17 @@ class PreferencesGeneralViewController <  NSViewController
         @project_list.removeAllItems
         begin
             url = @server_url.stringValue[-1,1].eql?('/') ? @server_url.stringValue : @server_url.stringValue + '/'
-            @all_projects =  JenxConnection.new(url, @username.stringValue, @password.stringValue).all_projects
-            @all_projects['jobs'].each do |project|
-                @project_list.addItemWithObjectValue(project['name'])
-            end
-            
-            if !@prefs.default_project
-                @project_list.selectItemWithObjectValue(0)
-            else
-                @project_list.selectItemWithObjectValue(@prefs.default_project)
+            JenxConnection.new(url, @username.stringValue, @password.stringValue).all_projects do |all_projects|
+                @all_projects = all_projects
+                @all_projects['jobs'].each do |project|
+                    @project_list.addItemWithObjectValue(project['name'])
+                end
+                
+                if !@prefs.default_project
+                    @project_list.selectItemWithObjectValue(0)
+                    else
+                    @project_list.selectItemWithObjectValue(@prefs.default_project)
+                end
             end
         rescue URI::InvalidURIError => uri_error
             NSLog(uri_error.inspect)


### PR DESCRIPTION
Instead of blocking on the completion of HTTP requests using
`JenxConnectionManager::value` (which does a GCD group wait and thus
blocks the main thread and makes the UI unresponsive), allow GCD tasks
to run asynchronously and call the passed-in block on the main thread
via `Dispatch::Queue.main.async` (because UI stuff must be done on the
main thread to prevent crashes). This eliminates the spinning beach ball
when Jenx is doing HTTP requests to retrieve the status from Jenkins.

Fixes GH-37.
